### PR TITLE
Added a punctuation

### DIFF
--- a/docs/v5/user-why-arent-columns-showing-in-pdf.md
+++ b/docs/v5/user-why-arent-columns-showing-in-pdf.md
@@ -7,7 +7,7 @@ description: "Gravity PDF attempts to match the same layout as your form when us
 ![Gravity PDF Three Column Layout Support using CSS Ready Classes](https://resources.gravitypdf.com/uploads/2016/05/three-column-layout.png)
 _Gravity PDF Three Column Layout Support using CSS Ready Classes_
 
-[In Core and some Universal PDFs](user-css-ready-classes.md), Gravity PDF attempts to match the same layout as your form [when using CSS Ready Classes](https://docs.gravityforms.com/css-ready-classes/). For instance, if you use the `gf_left_half` and `gf_right_half` classes on two fields that are next to each other in the form builder this will create a two column layout in the PDF (and your form). We also support three column layouts with the `gf_left_third`, `gf_middle_third` and `gf_right_third` field classes.
+[In Core and some Universal PDFs](user-css-ready-classes.md), Gravity PDF attempts to match the same layout as your form [when using CSS Ready Classes](https://docs.gravityforms.com/css-ready-classes/). For instance, if you use the `gf_left_half` and `gf_right_half` classes on two fields that are next to each other in the form builder, this will create a two column layout in the PDF (and your form). We also support three column layouts with the `gf_left_third`, `gf_middle_third` and `gf_right_third` field classes.
 
 Provided you aren't using a half or three column layout on checkbox or radio button fields, we also support `gf_list_2col`, `gf_list_3col`, `gf_list_4col` and `gf_list_5col` classes in the PDF. **The class `gf_list_inline` is not supported.**
 


### PR DESCRIPTION
[Why aren't Columns Showing in PDF?](https://gravity-pdf-documentation.onrender.com/v5/user-why-arent-columns-showing-in-pdf)
- Paragraph 1, sentence 2: added a comma after the word **builder,**