### PR TITLE
Fixed a link and added punctuations

### DIFF
--- a/docs/v5/shop-installing-upgrading-extensions.md
+++ b/docs/v5/shop-installing-upgrading-extensions.md
@@ -7,7 +7,7 @@ description: "After purchasing, you'll receive an email containing a link to you
 You've purchased a [premium extension/plugin through our online store](https://gravitypdf.com/extension-shop/). The next step is to install it on your website.
 
 :::info 
-Before you begin please ensure you have the [Gravity Forms](https://rocketgenius.pxf.io/c/1211356/445235/7938) and [Gravity PDF](five-minute-install.md) plugins both active on your WordPress website. Done? Good! Now let's get you up and running with your new premium plugin.
+Before you begin, please ensure you have the [Gravity Forms](https://rocketgenius.pxf.io/c/1211356/445235/7938) and [Gravity PDF](five-minute-install.md) plugins both active on your WordPress website. Done? Good! Now let's get you up and running with your new premium plugin.
 :::
 
 Once you've completed your purchase you'll receive an email containing a link to your plugin zip file – the email also contains your product key which will give you access to support and one-click updates: keep it safe!
@@ -15,7 +15,7 @@ Once you've completed your purchase you'll receive an email containing a link to
 ## Install Steps 
 
 :::note
-If your browser auto-extracts zip files when downloaded you'll need to temporarily disable this functionality to prevent issues during installation. [See how to disable this in Safari](http://apple.stackexchange.com/a/963).
+If your browser auto-extracts zip files when downloaded, you'll need to temporarily disable this functionality to prevent issues during installation. [See how to disable this in Safari](http://apple.stackexchange.com/a/963).
 :::
 
 1.  Open the Shop Receipt email you received and locate the *Your Purchases* section. Click the link to download the plugin zip package.
@@ -32,11 +32,11 @@ If your browser auto-extracts zip files when downloaded you'll need to temporari
 
 6.  To enable one-click updates, locate the newly-installed plugin in the list and click the "Register your copy of *PLUGIN\_NAME*" link.
 
-7.  Enter then save your license key (found in your Receipt email). If the registration is successful a tick will be displayed next to the license.
+7.  Enter then save your license key (found in your Receipt email). If the registration is successful, a tick will be displayed next to the license.
     ![Registering plugin for one-click updates](https://resources.gravitypdf.com/uploads/2017/06/plugin-licensing.png)
 
 ## One Click Updates 
 
-As long as you've registered your license key (as outlined in the [Install Steps](#install-steps)) and it's still valid (all keys are valid for 12 months after purchase), your extension will periodically check GravityPDF.com for a new version. If there is a new version, it'll be shown on the [Dashboard Updates Screen](https://codex.wordpress.org/Dashboard_Updates_Screen) or the Plugins page and you can one-click update the software.
+As long as you've registered your license key (as outlined in the [Install Steps](#install-steps)) and it's still valid (all keys are valid for 12 months after purchase), your extension will periodically check GravityPDF.com for a new version. If there is a new version, it'll be shown on the [Dashboard Updates Screen](https://wordpress.org/support/article/dashboard-updates-screen/) or the Plugins page, and you can one-click update the software.
 
 ![One-click updates](https://resources.gravitypdf.com/uploads/2017/06/core-booster-update.png)


### PR DESCRIPTION
[How to install your premium Gravity PDF extension](https://gravity-pdf-documentation.onrender.com/v5/shop-installing-upgrading-extensions)
- INFO box, sentence 1: added a comma after the word **begin,**

[Install Steps](https://gravity-pdf-documentation.onrender.com/v5/shop-installing-upgrading-extensions#install-steps)
 - NOTE box: added a comma after the word **downloaded,**
 - Item 7, sentence 2: added a comma after the word **successful,**

[One Click Updates](https://gravity-pdf-documentation.onrender.com/v5/shop-installing-upgrading-extensions#install-steps)
 - Paragraph 1, sentence 2 : changed the link [Dashboard Updates Screen](https://wordpress.org/support/article/dashboard-updates-screen/) (https://wordpress.org/support/article/dashboard-updates-screen/)
 - Paragraph 1, sentence 2: added a comma after the word **page,**