### PR TITLE
Fixed a link and added a punctuation

### DIFF
--- a/docs/v5/developer-template-hierarchy.md
+++ b/docs/v5/developer-template-hierarchy.md
@@ -12,7 +12,7 @@ We [touched on the template hierarchy](developer-first-custom-pdf.md#template-hi
 
 ![WordPress Standard Template Hierarchy](https://resources.gravitypdf.com/uploads/2015/11/WordPress-Standard-Hierarchy.png)
 
-On a standard WordPress installation the template hierarchy is straightforward. Files in the [PDF Working Directory](developer-first-custom-pdf.md#working-directory) override templates that ship with the plugin – provided they have the same name. [When you prepare your website for custom PDF templates](developer-first-custom-pdf.md#preparing-the-infrastructure) all the plugin's template files are copied over to your PDF working directory so you can override the settings if you wish. It's straightforward and easy.
+On a standard WordPress installation, the template hierarchy is straightforward. Files in the [PDF Working Directory](developer-first-custom-pdf.md#working-directory) override templates that ship with the plugin – provided they have the same name. [When you prepare your website for custom PDF templates](developer-first-custom-pdf.md#preparing-the-infrastructure) all the plugin's template files are copied over to your PDF working directory so you can override the settings if you wish. It's straightforward and easy.
 
 ## Multisite WordPress Installation 
 
@@ -20,4 +20,4 @@ On a standard WordPress installation the template hierarchy is straightforward. 
 
 To allow more flexibility with PDF templates, Multisite installations add another layer to the template hierarchy. Each site in a Multisite installation [gets its own PDF Working Directory](developer-first-custom-pdf.md#multisite-structure), so different sites can have their own templates that won't be included for other subsites. If installing a template via the [PDF Template Manager](user-pdf-template-manager.md), it'll be saved in the subsite directory and not directly in the [Working Directory](developer-first-custom-pdf.md#working-directory).
 
-Individual site templates override any global templates in the `PDF_EXTENDED_TEMPLATES` directory (which apply to all Multisite installations), which in turn override the Core Gravity PDF templates (like in a [standard WordPress installation](#standard-wordpress-install)).
+Individual site templates override any global templates in the `PDF_EXTENDED_TEMPLATES` directory (which apply to all Multisite installations), which in turn override the Core Gravity PDF templates (like in a [standard WordPress installation](#standard-wordpress-installation)).


### PR DESCRIPTION
[Standard WordPress Installation](https://gravity-pdf-documentation.onrender.com/v5/developer-template-hierarchy#standard-wordpress-installation)
 - Paragraph 1, sentence 1: added a comma after the word **installation,**

[Multisite WordPress Installation](https://gravity-pdf-documentation.onrender.com/v5/developer-template-hierarchy#multisite-wordpress-installation)
 - Paragraph 2, sentence 1: changed the link [standard WordPress installation](#standard-wordpress-installation) (#standard-wordpress-installation)