### PR TITLE
Added punctuations

### DIFF
--- a/docs/v5/developer-tables.md
+++ b/docs/v5/developer-tables.md
@@ -1,5 +1,5 @@
 ---
-title: "Custom Template Table Formating and its Quirks in PDFs"
+title: "Custom Template Table Formatting and its Quirks in PDFs"
 sidebar_label: "Tables"
 description: "There is quite good support for HTML tables in mPDF, but it does have its quirks. Use tables for tabular data and you'll find them a treat."
 ---
@@ -8,11 +8,11 @@ description: "There is quite good support for HTML tables in mPDF, but it does h
 
 There is quite good support for HTML tables in [mPDF](http://mpdf.github.io/), but it does have its quirks. The two biggest issues you might face when using tables are:
 
-1.  **Unsupported Block Elements**. All block elements included in table cells are ignored. The content will still be displayed but you won't be able to directly style the elements using CSS (you can still apply styles to the table cell directly).
+1.  **Unsupported Block Elements**. All block elements included in table cells are ignored. The content will still be displayed, but you won't be able to directly style the elements using CSS (you can still apply styles to the table cell directly).
 
-2.  **Autosizing.** On a website, if a table is too large for its container it might overflow outside it, or use a horizontal scroll bar. Because PDFs cannot do those things it instead alters the column widths and font sizes. Basically, mPDF places more priority on producing a pleasing, efficiently laid out table than it does respecting defined widths and sizes. [But there are ways to minimise this effect](#table-rendering).
+2.  **Autosizing.** On a website, if a table is too large for its container, it might overflow outside it, or use a horizontal scroll bar. Because PDFs cannot do those things, it instead alters the column widths and font sizes. Basically, mPDF places more priority on producing a pleasing, efficiently laid out table than it does respecting defined widths and sizes. [But there are ways to minimise this effect](#table-rendering).
 
-Because of these two issues tables have limited use when designing your PDF layout. We've found [carefully calculated floats](developer-floats.md) is the better option for producing more complex designs. Use tables for tabular data and you'll find them a treat.
+Because of these two issues, tables have limited use when designing your PDF layout. We've found [carefully calculated floats](developer-floats.md) is the better option for producing more complex designs. Use tables for tabular data, and you'll find them a treat.
 
 ![Example of Tables rendered in mPDF](https://resources.gravitypdf.com/uploads/2015/11/table-preview.png)
 
@@ -30,7 +30,7 @@ Other problems with cell width can occur when you have fixed widths applied to `
 
 1. You can set the width of a cell [using any Length measuring unit supported by mPDF](http://mpdf.github.io/css-stylesheets/supported-css.html). The most common are `mm`, `%`, `px` and `in`, while the easiest to work with is percentages `%`. 
 
-2.  Only add a width to the first row in your table – either inline, or using CSS classes.
+2.  Only add a width to the first row in your table – either inline or using CSS classes.
 
 3.  Don't add a width to at least one of your columns.
 
@@ -58,7 +58,7 @@ If a table extends across multiple pages the `<thead></thead>` and `<tfoot></tfo
 
 ## Rotating Table 
 
-Tables can be rotated 90 degrees clockwise or counter-clockwise so they fit nicely on portrait documents. This feature can be applied using the CSS `rotate` property.
+Tables can be rotated 90 degrees clockwise or counter-clockwise, so they fit nicely on portrait documents. This feature can be applied using the CSS `rotate` property.
 
 ```css
 #clockwise {
@@ -74,7 +74,7 @@ Tables can be rotated 90 degrees clockwise or counter-clockwise so they fit nice
 
 [We’ve put together a sample showing off the table support in Gravity PDF](https://gist.github.com/jakejackson1/de009962d7ec776d223c).
 
-For more information about the methods discussed we recommend reviewing the mPDF documentation:
+For more information about the methods discussed, we recommend reviewing the mPDF documentation:
 
 -   [Tables](http://mpdf.github.io/tables/tables.html)
 -   [Table Layout](http://mpdf.github.io/tables/table-layout.html)


### PR DESCRIPTION
[Custom Template Table Formatting and its Quirks in PDFs](https://gravity-pdf-documentation.onrender.com/v5/developer-tables)
 - Heading 1: changed the word **Formating** to **Formatting**

[Introduction](https://gravity-pdf-documentation.onrender.com/v5/developer-tables#introduction)
 - Item 1, sentence 2: added a comma after the word **displayed,**
 - Item 2, sentence 2: added a comma after the word **container,**
 - Item 2, sentence 2: added a comma after the word **things,**
 - Paragraph 2, sentence 1: added a comma after the word **issues,**
 - Paragraph 2, sentence 3: added a comma after the word **data,**

[Table Rendering](https://gravity-pdf-documentation.onrender.com/v5/developer-tables#table-rendering)
 - Item 2: removed the comma after the word **inline**

[Rotating Table](https://gravity-pdf-documentation.onrender.com/v5/developer-tables#rotating-table)
 - Paragraph 2, sentence 1: added a comma after the word **counter-clockwise,**

[Example](https://gravity-pdf-documentation.onrender.com/v5/developer-tables#example)
 - Paragraph 2: added a comma after the word **discussed,**