### PR TITLE
Fixed a word and added a punctuation

### DIFF
--- a/docs/v5/gfpdf_core_template_fields_list.md
+++ b/docs/v5/gfpdf_core_template_fields_list.md
@@ -32,7 +32,7 @@ add_action( 'gfpdf_core_template_fields_list', function( $fields, $template_sett
 
 /**
  * This is our callback function which includes our new field details
- * If a PDF template configuration passes `prefix_custom_core_field` as true in it's core array this field will now show on the PDF template tab
+ * If a PDF template configuration passes `prefix_custom_core_field` as true in its core array this field will now show on the PDF template tab
  */
 function prefix_custom_core_field_function() {
 	return array(
@@ -50,7 +50,7 @@ function prefix_custom_core_field_function() {
 }
 ```
 
-While this adds a new core field you still need to process the value when set. Use the [`gfpdf_core_template`](gfpdf_core_template.md) action to do this. 
+While this adds a new core field, you still need to process the value when set. Use the [`gfpdf_core_template`](gfpdf_core_template.md) action to do this. 
 
 ## Source Code 
 


### PR DESCRIPTION
[Usage](https://gravity-pdf-documentation.onrender.com/v5/gfpdf_core_template_fields_list#usage)
 - Code block, under `function prefix_custom_core_field_function()`, sentence 2: changed the word **it’s** to **its**
 - Paragraph 2, sentence 1: added a comma after the word **field,**