### PR TITLE
Fixed a link

### DIFF
--- a/docs/v5/gfpdf_enable_master_password_field.md
+++ b/docs/v5/gfpdf_enable_master_password_field.md
@@ -8,7 +8,7 @@ description: ""
 
 ## Description 
 
-Use this filter to enable the PDF Master Password in the Advanced tab when the [Security option is enabled](user-setup-pdf.md#pdf-security).
+Use this filter to enable the PDF Master Password in the Advanced tab when the [Security option is enabled](user-setup-pdf.md#enable-pdf-security).
 
 ## Version 
 


### PR DESCRIPTION
[Description](https://gravity-pdf-documentation.onrender.com/v5/gfpdf_enable_master_password_field#description)
 - Sentence 1: changed the link [Security option is disabled](user-setup-pdf.md#enable-pdf-security) (user-setup-pdf.md#enable-pdf-security)