### PR TITLE
Added a punctuation

### DIFF
--- a/docs/v5/gfpdf_tool_tab_actions.md
+++ b/docs/v5/gfpdf_tool_tab_actions.md
@@ -51,7 +51,7 @@ add_action( 'gfpdf_tool_tab_actions', function( $settings ) {
 		}
 
 		/**
-		 * If we are here the user has correctly authenticated and they want your action to run
+		 * If we are here the user has correctly authenticated, and they want your action to run
 		 * Include all your action handling code below.
 		 */
 		//unlink( '/path/to/log/files' );


### PR DESCRIPTION
[Usage](https://gravity-pdf-documentation.onrender.com/v5/gfpdf_tool_tab_actions#usage)
 - Code block, under `$notices->add_notice`, sentence 2: added a comma after the word **authenticated,**